### PR TITLE
add code to pull portlnd1. add to wrapper.

### DIFF
--- a/stata_code/data_extraction_processing/extraction/commercial/01_extraction_wrapper.do
+++ b/stata_code/data_extraction_processing/extraction/commercial/01_extraction_wrapper.do
@@ -33,3 +33,6 @@ do "$extraction_code/commercial/bsb_dersource_investigations.do"
 
 do "$extraction_code/commercial/observer_fuel_prices.do"
 
+
+
+do "$extraction_code/commercial/portlnd1_supplement.do"

--- a/stata_code/data_extraction_processing/extraction/commercial/portlnd1_supplement.do
+++ b/stata_code/data_extraction_processing/extraction/commercial/portlnd1_supplement.do
@@ -1,0 +1,31 @@
+#delimit ;
+/* Pull portlnd1 and other data for mergeing from TRIP_REPORTS_DOCUMENT
+We already have portlnd1 through 2022. This pulls all. 
+The earlier data had some data cleaning done on portlnd1. 
+
+As a first pass, I would probably do a
+
+merge 1:1 permit tripid dbyear using portlnd1_supplement, update  
+
+and NOT
+
+merge ... , update replace
+
+
+ */
+clear;
+
+
+
+local sql "select vessel_permit_num as permit, to_char(docid) as tripid, port1_number as port, port1 as portlnd1, state1, extract(YEAR from DATE_LAND) as dbyear 
+    from NEFSC_GARFO.TRIP_REPORTS_DOCUMENT
+    where extract(YEAR from DATE_LAND) >=1996
+    order by dbyear, permit, tripid " ;
+		
+clear;
+
+odbc load, exec("`sql'")  $myNEFSC_USERS_conn;
+destring permit, replace;
+
+save ${data_main}\commercial\portlnd1_supplement_${vintage_string}.dta, replace ;
+


### PR DESCRIPTION
code to freshly pull the raw portlnd1, state1 columns.  This is for all years, but we don't necessarily need them all.

this will close #4 

The original code did some data cleaning. Looked through it and so much of the underlying data tables have been changed in the past 2 years. It's going to take a long time to figure out how to clean that out. Perhaps an infinite time.